### PR TITLE
Set published date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,14 +92,14 @@ jobs:
                 run: |
                     cd temp/cms
                     composer config --unset extra.branch-alias.dev-master
-                    composer config extra.branch-alias.dev-$CI_REF_NAME_SLUG 0.1.x-dev
+                    composer config extra.branch-alias.dev-$CI_REF_NAME_SLUG 0.2.x-dev
 
             -   name: Create temporary branch alias for pull requests
                 if: startsWith(github.ref, 'refs/pull/')
                 run: |
                     cd temp/cms
                     composer config --unset extra.branch-alias.dev-master
-                    composer config extra.branch-alias.dev-$CI_SHA 0.1.x-dev
+                    composer config extra.branch-alias.dev-$CI_SHA 0.2.x-dev
 
             -   name: Setup PHP
                 id: setup-php

--- a/src/Bundle/Resources/config/services.yaml
+++ b/src/Bundle/Resources/config/services.yaml
@@ -66,6 +66,9 @@ services:
     NumberNine\Theme\CssFramework\CssFrameworkInterface: '@NumberNine\Theme\CssFramework\TailwindCss'
     NumberNine\Theme\TemplateResolverInterface: '@NumberNine\Theme\TemplateResolver'
 
+    NumberNine\EventSubscriber\ContentEntityPublishEventSubscriber:
+        tags:
+            - { name: 'doctrine.event_subscriber' }
 
     NumberNine\EventSubscriber\MediaFileDeletionEventSubscriber:
         tags:

--- a/src/Bundle/Resources/views/admin/util/content_entities_table.html.twig
+++ b/src/Bundle/Resources/views/admin/util/content_entities_table.html.twig
@@ -8,7 +8,7 @@
             {% else %}
                 <th class="w-32">{{ 'Image'|trans }}</th>
             {% endif %}
-            <th class="w-96">{{ 'Title'|trans }}</th>
+            <th class="w-1/3">{{ 'Title'|trans }}</th>
             <th>{{ 'Author'|trans }}</th>
             <th>{{ 'Categories'|trans }}</th>
             <th>{{ 'Tags'|trans }}</th>

--- a/src/Content/PermalinkGenerator.php
+++ b/src/Content/PermalinkGenerator.php
@@ -51,9 +51,8 @@ final class PermalinkGenerator
 
         $route = $this->routeProvider->getRouteByName($routeName);
 
-        /** @var DateTime $date */
         $date = $contentEntity->getStatus() === PublishingStatusInterface::STATUS_PUBLISH
-            ? $contentEntity->getPublishedAt()
+            ? $contentEntity->getPublishedAt() ?? $contentEntity->getCreatedAt()
             : $contentEntity->getCreatedAt();
 
         $parameters = [];

--- a/src/Controller/Admin/Ui/ContentEntity/ContentEntityCreateAction.php
+++ b/src/Controller/Admin/Ui/ContentEntity/ContentEntityCreateAction.php
@@ -30,6 +30,7 @@ final class ContentEntityCreateAction extends AbstractContentEntityFormAction
 
         $class = $contentType->getEntityClassName();
         $entity = (new $class())
+            ->setAuthor($this->getUser())
             ->setCustomType($contentType->getName())
             ->setCustomFields(null)
         ;

--- a/src/EventSubscriber/ContentEntityPublishEventSubscriber.php
+++ b/src/EventSubscriber/ContentEntityPublishEventSubscriber.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the NumberNine package.
+ *
+ * (c) William Arin <williamarin.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace NumberNine\EventSubscriber;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\ORM\Events;
+use NumberNine\Entity\ContentEntity;
+use NumberNine\Model\Content\PublishingStatusInterface;
+
+final class ContentEntityPublishEventSubscriber implements EventSubscriber
+{
+    public function getSubscribedEvents(): array
+    {
+        return [
+            Events::prePersist,
+            Events::preUpdate,
+        ];
+    }
+
+    public function prePersist(LifecycleEventArgs $args): void
+    {
+        $this->update($args);
+    }
+
+    public function preUpdate(LifecycleEventArgs $args): void
+    {
+        $this->update($args);
+    }
+
+    private function update(LifecycleEventArgs $args): void
+    {
+        /** @var ContentEntity $entity */
+        $entity = $args->getEntity();
+
+        if ($entity instanceof ContentEntity && $entity->getStatus() === PublishingStatusInterface::STATUS_PUBLISH) {
+            $entity->setPublishedAt(new \DateTime());
+        }
+    }
+}


### PR DESCRIPTION
Fixes a bug that caused admin entities index pages to throw an exception because `publishedAt` field wasn't properly set.