### PR TITLE
Allow '0' value to appear in generated shortcode attributes

### DIFF
--- a/src/Content/ArrayToShortcodeConverter.php
+++ b/src/Content/ArrayToShortcodeConverter.php
@@ -34,7 +34,7 @@ final class ArrayToShortcodeConverter
 
         $parameters = array_filter(
             $array['parameters'],
-            static fn($v, $k) => $v && $k !== 'content',
+            static fn($v, $k) => !is_array($v) && $v !== '' && $v !== null && $v !== false && $k !== 'content',
             ARRAY_FILTER_USE_BOTH,
         );
 

--- a/src/Shortcode/SectionShortcode.php
+++ b/src/Shortcode/SectionShortcode.php
@@ -48,7 +48,6 @@ final class SectionShortcode extends AbstractShortcode implements EditableShortc
             ->add('backgroundColor', ColorControl::class)
             ->add('backgroundPosition')
             ->add('backgroundOverlay', ColorControl::class)
-            ->add('height')
             ->add('margin', BordersControl::class)
             ->add('padding', BordersControl::class)
             ->add('color', ButtonToggleControl::class, ['choices' => [
@@ -68,7 +67,6 @@ final class SectionShortcode extends AbstractShortcode implements EditableShortc
             'backgroundColor' => '',
             'backgroundPosition' => '',
             'backgroundOverlay' => [],
-            'height' => 0,
             'margin' => '0px',
             'padding' => '30px',
             'color' => 'light',
@@ -78,6 +76,7 @@ final class SectionShortcode extends AbstractShortcode implements EditableShortc
     public function processParameters(array $parameters): array
     {
         return [
+            'container' => $parameters['container'],
             'color' => $parameters['color'],
             'styles' => $this->getStyles($parameters),
             'backgroundStyles' => $this->getBackgroundStyles($parameters),

--- a/tests/Unit/Content/ArrayToShortcodeConverterTest.php
+++ b/tests/Unit/Content/ArrayToShortcodeConverterTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the NumberNine package.
+ *
+ * (c) William Arin <williamarin.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace NumberNine\Tests\Unit\Content;
+
+use NumberNine\Content\ArrayToShortcodeConverter;
+use NumberNine\Tests\DotEnvAwareWebTestCase;
+
+final class ArrayToShortcodeConverterTest extends DotEnvAwareWebTestCase
+{
+    private ArrayToShortcodeConverter $arrayToShortcodeConverter;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->client->request('GET', '/');
+        $this->arrayToShortcodeConverter = static::getContainer()->get(ArrayToShortcodeConverter::class);
+    }
+
+    public function testConvertSingleComponentToShortcode(): void
+    {
+        $shortcode = $this->arrayToShortcodeConverter->convertMany([
+            [
+                'name' => 'my_shortcode',
+                'parameters' => [
+                    'content' => 'Some content',
+                    'margin' => '0px',
+                    'padding' => '0',
+                    'color' => 'light',
+                    'empty' => '',
+                    'null_value' => null,
+                    'integer_zero' => 0,
+                    'camelCase' => 'ok',
+                    'snake_case' => 'ok',
+                ],
+                'children' => [],
+            ],
+        ]);
+
+        $this->assertEquals(
+            '[my_shortcode margin="0px" padding="0" color="light" integer_zero="0" ' .
+            'camelCase="ok" snake_case="ok"]Some content[/my_shortcode]',
+            $shortcode
+        );
+    }
+}


### PR DESCRIPTION
Before it was filtered, causing problems with default values.

For example if a shortcode had a default value `padding: 30px`, it wasn't possible to set it to `0` from the page builder unless writing the shortcode manually.