### PR TITLE
Private pages

### DIFF
--- a/src/Content/PermalinkGenerator.php
+++ b/src/Content/PermalinkGenerator.php
@@ -57,9 +57,7 @@ final class PermalinkGenerator
         $route = $this->routeProvider->getRouteByName($routeName);
 
         /** @var ?DateTime $date */
-        $date = $contentEntity->getStatus() === PublishingStatusInterface::STATUS_PUBLISH
-            ? $contentEntity->getPublishedAt() ?? $contentEntity->getCreatedAt()
-            : $contentEntity->getCreatedAt();
+        $date = $contentEntity->getPublishedAt() ?? $contentEntity->getCreatedAt();
 
         if ($date === null) {
             $date = new DateTime();

--- a/src/Controller/Frontend/Content/ContentEntityShowAction.php
+++ b/src/Controller/Frontend/Content/ContentEntityShowAction.php
@@ -28,6 +28,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 /**
 * The route of this action is dynamically generated
@@ -67,7 +68,11 @@ final class ContentEntityShowAction extends AbstractController
 
         $this->validateUrl($request, $entity, $permalinkGenerator);
 
-        $this->denyAccessUnlessGranted(Capabilities::READ, $entity);
+        try {
+            $this->denyAccessUnlessGranted(Capabilities::READ, $entity);
+        } catch (AccessDeniedException $e) {
+            throw $this->createNotFoundException('This page does not exist.');
+        }
 
         $eventDispatcher->dispatch(new CurrentContentEntityEvent($entity));
 

--- a/src/Entity/Comment.php
+++ b/src/Entity/Comment.php
@@ -76,7 +76,7 @@ class Comment
      * @ORM\ManyToOne(targetEntity="NumberNine\Entity\User", inversedBy="comments")
      * @Groups("author_get")
      */
-    protected ?User $author;
+    protected ?User $author = null;
 
     /**
      * Comment constructor.

--- a/src/Entity/ContentEntity.php
+++ b/src/Entity/ContentEntity.php
@@ -117,7 +117,7 @@ class ContentEntity implements PublishingStatusInterface, CommentStatusInterface
      * @ORM\ManyToOne(targetEntity="NumberNine\Entity\User", inversedBy="contentEntities")
      * @Groups({"author_get", "content_entity_get_full"})
      */
-    protected ?User $author;
+    protected ?User $author = null;
 
     public function __construct()
     {

--- a/src/EventSubscriber/ComponentProcessParametersEventSubscriber.php
+++ b/src/EventSubscriber/ComponentProcessParametersEventSubscriber.php
@@ -15,7 +15,7 @@ use NumberNine\Event\ComponentProcessParametersEvent;
 use NumberNine\Content\DataTransformerProcessor;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-final class ShortcodeRenderEventSubscriber implements EventSubscriberInterface
+final class ComponentProcessParametersEventSubscriber implements EventSubscriberInterface
 {
     private DataTransformerProcessor $dataTransformerProcessor;
 
@@ -24,7 +24,7 @@ final class ShortcodeRenderEventSubscriber implements EventSubscriberInterface
         $this->dataTransformerProcessor = $dataTransformerProcessor;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             ComponentProcessParametersEvent::class => 'transformValues'

--- a/src/Model/Content/Features/AuthorTrait.php
+++ b/src/Model/Content/Features/AuthorTrait.php
@@ -21,7 +21,7 @@ trait AuthorTrait
      * @ORM\ManyToOne(targetEntity="NumberNine\Entity\User")
      * @Groups({"author_get", "content_entity_get_full"})
      */
-    protected ?User $author;
+    protected ?User $author = null;
 
     public function getAuthor(): ?User
     {

--- a/src/Model/Content/Features/CustomFieldsTrait.php
+++ b/src/Model/Content/Features/CustomFieldsTrait.php
@@ -21,7 +21,7 @@ trait CustomFieldsTrait
      * @Groups({"custom_fields_get", "content_entity_get_full"})
      * @var array|null
      */
-    private ?array $customFields;
+    private ?array $customFields = null;
 
     public function getCustomFields(): ?array
     {

--- a/src/Model/Content/Features/EditorTrait.php
+++ b/src/Model/Content/Features/EditorTrait.php
@@ -22,14 +22,14 @@ trait EditorTrait
      * @Groups({"editor_get", "content_entity_get_full"})
      * @Gedmo\Versioned
      */
-    private ?string $content;
+    private ?string $content = null;
 
     /**
      * @ORM\Column(type="text", nullable=true)
      * @Groups({"editor_get", "content_entity_get_full"})
      * @Gedmo\Versioned
      */
-    private ?string $excerpt;
+    private ?string $excerpt = null;
 
     public function getContent(): ?string
     {

--- a/src/Security/Capability/ReadCapability.php
+++ b/src/Security/Capability/ReadCapability.php
@@ -48,7 +48,10 @@ final class ReadCapability implements CapabilityInterface
         $plural = current($this->inflector->pluralize($entity->getType()));
 
         if ($entity->isPrivate()) {
-            if ($this->security->isGranted(sprintf('read_private_%s', $plural))) {
+            if (
+                $this->security->isGranted(sprintf('read_private_%s', $plural))
+                || $entity->getAuthor() === $user
+            ) {
                 return VoterInterface::ACCESS_GRANTED;
             }
 

--- a/src/Security/Voter/ReaderVoter.php
+++ b/src/Security/Voter/ReaderVoter.php
@@ -11,6 +11,7 @@
 
 namespace NumberNine\Security\Voter;
 
+use NumberNine\Entity\User;
 use NumberNine\Security\Capabilities;
 use NumberNine\Security\Capability\CapabilityInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -36,6 +37,9 @@ final class ReaderVoter extends Voter
 
     protected function voteOnAttribute(string $attribute, $subject, TokenInterface $token): bool
     {
-        return $this->readCapability->handle($subject, null) === VoterInterface::ACCESS_GRANTED;
+        /** @var ?User $user */
+        $user = $token->getUser() instanceof User ? $token->getUser() : null;
+
+        return $this->readCapability->handle($subject, $user) === VoterInterface::ACCESS_GRANTED;
     }
 }

--- a/tests/Functional/Controller/Admin/Api/PageBuilder/PageBuilderAreaComponentsGetActionTest.php
+++ b/tests/Functional/Controller/Admin/Api/PageBuilder/PageBuilderAreaComponentsGetActionTest.php
@@ -12,9 +12,9 @@
 namespace NumberNine\Tests\Functional\Controller\Admin\Api\PageBuilder;
 
 use NumberNine\Security\Capabilities;
-use NumberNine\Tests\Functional\AdminTestCase;
+use NumberNine\Tests\Functional\UserAwareTestCase;
 
-final class PageBuilderAreaComponentsGetActionTest extends AdminTestCase
+final class PageBuilderAreaComponentsGetActionTest extends UserAwareTestCase
 {
     public function testNotLoggedInUserCantAccessUrl(): void
     {

--- a/tests/Functional/Controller/Admin/Ui/Dashboard/DashboardIndexActionTest.php
+++ b/tests/Functional/Controller/Admin/Ui/Dashboard/DashboardIndexActionTest.php
@@ -12,9 +12,9 @@
 namespace NumberNine\Tests\Functional\Controller\Admin\Ui\Dashboard;
 
 use NumberNine\Security\Capabilities;
-use NumberNine\Tests\Functional\AdminTestCase;
+use NumberNine\Tests\Functional\UserAwareTestCase;
 
-final class DashboardIndexActionTest extends AdminTestCase
+final class DashboardIndexActionTest extends UserAwareTestCase
 {
     public function testAdminPageRedirectsToLogin(): void
     {

--- a/tests/Functional/Controller/Admin/Ui/MediaLibrary/MediaIndexActionTest.php
+++ b/tests/Functional/Controller/Admin/Ui/MediaLibrary/MediaIndexActionTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace NumberNine\Tests\Functional\Controller\Admin\Ui\MediaLibrary;
 
-use NumberNine\Tests\Functional\AdminTestCase;
+use NumberNine\Tests\Functional\UserAwareTestCase;
 
-final class MediaIndexActionTest extends AdminTestCase
+final class MediaIndexActionTest extends UserAwareTestCase
 {
     public function testAdministratorCanAccessMediaLibrary(): void
     {

--- a/tests/Functional/Controller/Admin/Ui/Menu/MenuCreateActionTest.php
+++ b/tests/Functional/Controller/Admin/Ui/Menu/MenuCreateActionTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace NumberNine\Tests\Functional\Controller\Admin\Ui\Menu;
 
-use NumberNine\Tests\Functional\AdminTestCase;
+use NumberNine\Tests\Functional\UserAwareTestCase;
 
-final class MenuCreateActionTest extends AdminTestCase
+final class MenuCreateActionTest extends UserAwareTestCase
 {
     public function testAdministratorCanAccessMediaLibrary(): void
     {

--- a/tests/Functional/Controller/Admin/Ui/Menu/MenuIndexActionTest.php
+++ b/tests/Functional/Controller/Admin/Ui/Menu/MenuIndexActionTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace NumberNine\Tests\Functional\Controller\Admin\Ui\Menu;
 
-use NumberNine\Tests\Functional\AdminTestCase;
+use NumberNine\Tests\Functional\UserAwareTestCase;
 
-final class MenuIndexActionTest extends AdminTestCase
+final class MenuIndexActionTest extends UserAwareTestCase
 {
     public function testAdministratorCanAccessMediaLibrary(): void
     {

--- a/tests/Functional/Controller/Admin/Ui/Settings/SettingsEmailsActionTest.php
+++ b/tests/Functional/Controller/Admin/Ui/Settings/SettingsEmailsActionTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace NumberNine\Tests\Functional\Controller\Admin\Ui\Settings;
 
-use NumberNine\Tests\Functional\AdminTestCase;
+use NumberNine\Tests\Functional\UserAwareTestCase;
 
-final class SettingsEmailsActionTest extends AdminTestCase
+final class SettingsEmailsActionTest extends UserAwareTestCase
 {
     public function testAdministratorCanAccessMediaLibrary(): void
     {

--- a/tests/Functional/Controller/Admin/Ui/Settings/SettingsGeneralActionTest.php
+++ b/tests/Functional/Controller/Admin/Ui/Settings/SettingsGeneralActionTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace NumberNine\Tests\Functional\Controller\Admin\Ui\Settings;
 
-use NumberNine\Tests\Functional\AdminTestCase;
+use NumberNine\Tests\Functional\UserAwareTestCase;
 
-final class SettingsGeneralActionTest extends AdminTestCase
+final class SettingsGeneralActionTest extends UserAwareTestCase
 {
     public function testAdministratorCanAccessMediaLibrary(): void
     {

--- a/tests/Functional/Controller/Admin/Ui/Settings/SettingsPermalinksActionTest.php
+++ b/tests/Functional/Controller/Admin/Ui/Settings/SettingsPermalinksActionTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace NumberNine\Tests\Functional\Controller\Admin\Ui\Settings;
 
-use NumberNine\Tests\Functional\AdminTestCase;
+use NumberNine\Tests\Functional\UserAwareTestCase;
 
-final class SettingsPermalinksActionTest extends AdminTestCase
+final class SettingsPermalinksActionTest extends UserAwareTestCase
 {
     public function testAdministratorCanAccessMediaLibrary(): void
     {

--- a/tests/Functional/Controller/Admin/Ui/User/UserCreateActionTest.php
+++ b/tests/Functional/Controller/Admin/Ui/User/UserCreateActionTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace NumberNine\Tests\Functional\Controller\Admin\Ui\User;
 
-use NumberNine\Tests\Functional\AdminTestCase;
+use NumberNine\Tests\Functional\UserAwareTestCase;
 
-final class UserCreateActionTest extends AdminTestCase
+final class UserCreateActionTest extends UserAwareTestCase
 {
     public function testAdministratorCanAccessMediaLibrary(): void
     {

--- a/tests/Functional/Controller/Admin/Ui/User/UserIndexActionTest.php
+++ b/tests/Functional/Controller/Admin/Ui/User/UserIndexActionTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace NumberNine\Tests\Functional\Controller\Admin\Ui\User;
 
-use NumberNine\Tests\Functional\AdminTestCase;
+use NumberNine\Tests\Functional\UserAwareTestCase;
 
-final class UserIndexActionTest extends AdminTestCase
+final class UserIndexActionTest extends UserAwareTestCase
 {
     public function testAdministratorCanAccessMediaLibrary(): void
     {

--- a/tests/Functional/Controller/Admin/Ui/UserRole/UserRoleCreateActionTest.php
+++ b/tests/Functional/Controller/Admin/Ui/UserRole/UserRoleCreateActionTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace NumberNine\Tests\Functional\Controller\Admin\Ui\UserRole;
 
-use NumberNine\Tests\Functional\AdminTestCase;
+use NumberNine\Tests\Functional\UserAwareTestCase;
 
-final class UserRoleCreateActionTest extends AdminTestCase
+final class UserRoleCreateActionTest extends UserAwareTestCase
 {
     public function testAdministratorCanAccessMediaLibrary(): void
     {

--- a/tests/Functional/Controller/Admin/Ui/UserRole/UserRoleIndexActionTest.php
+++ b/tests/Functional/Controller/Admin/Ui/UserRole/UserRoleIndexActionTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace NumberNine\Tests\Functional\Controller\Admin\Ui\UserRole;
 
-use NumberNine\Tests\Functional\AdminTestCase;
+use NumberNine\Tests\Functional\UserAwareTestCase;
 
-final class UserRoleIndexActionTest extends AdminTestCase
+final class UserRoleIndexActionTest extends UserAwareTestCase
 {
     public function testAdministratorCanAccessMediaLibrary(): void
     {

--- a/tests/Functional/Controller/Frontend/ContentEntityShowActionTest.php
+++ b/tests/Functional/Controller/Frontend/ContentEntityShowActionTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the NumberNine package.
+ *
+ * (c) William Arin <williamarin.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace NumberNine\Tests\Functional\Controller\Frontend;
+
+use NumberNine\Entity\Post;
+use NumberNine\Entity\User;
+use NumberNine\Model\Content\PublishingStatusInterface;
+use NumberNine\Security\Capabilities;
+use NumberNine\Tests\Functional\UserAwareTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ContentEntityShowActionTest extends UserAwareTestCase
+{
+    private function createPrivatePost(string $date, ?User $user = null): void
+    {
+        if (!$user) {
+            $user = $this->userFactory->createUser(
+                'contributor',
+                'contributor@numbernine-fakedomain.com',
+                'password',
+                [$this->userRoleRepository->findOneBy(['name' => 'Contributor'])],
+            );
+        }
+
+        $post = (new Post())
+            ->setCustomType('post')
+            ->setAuthor($user)
+            ->setTitle('This page is private')
+            ->setStatus(PublishingStatusInterface::STATUS_PRIVATE)
+            ->setCreatedAt(new \DateTime($date))
+        ;
+
+        $this->entityManager->persist($post);
+        $this->entityManager->flush();
+    }
+
+    public function testAccessingPrivatePostThrows404NotFound(): void
+    {
+        $this->createPrivatePost('2021/04/15');
+        $this->client->request('GET', '/2021/04/15/this-page-is-private');
+
+        self::assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    public function testAuthorCanAccessHisPrivatePost(): void
+    {
+        $user = $this->loginAs('Contributor');
+        $this->createPrivatePost('2021/04/15', $user);
+        $this->client->request('GET', '/2021/04/15/this-page-is-private');
+
+        self::assertResponseStatusCodeSame(Response::HTTP_OK);
+        self::assertSelectorTextSame('h1', 'This page is private');
+    }
+
+    public function testAllowedUsersCanAccessOtherUserPrivatePost(): void
+    {
+        $this->createPrivatePost('2021/04/15');
+        $this->setCapabilitiesThenLogin([Capabilities::READ_PRIVATE_POSTS]);
+        $this->client->request('GET', '/2021/04/15/this-page-is-private');
+
+        self::assertResponseStatusCodeSame(Response::HTTP_OK);
+        self::assertSelectorTextSame('h1', 'This page is private');
+    }
+}

--- a/tests/Functional/Controller/Frontend/ContentEntityShowActionTest.php
+++ b/tests/Functional/Controller/Frontend/ContentEntityShowActionTest.php
@@ -60,7 +60,7 @@ final class ContentEntityShowActionTest extends UserAwareTestCase
         $this->client->request('GET', '/2021/04/15/this-page-is-private');
 
         self::assertResponseStatusCodeSame(Response::HTTP_OK);
-        self::assertSelectorTextSame('h1', 'This page is private');
+        self::assertSelectorTextSame('h1', 'Private: This page is private');
     }
 
     public function testAllowedUsersCanAccessOtherUserPrivatePost(): void
@@ -70,6 +70,6 @@ final class ContentEntityShowActionTest extends UserAwareTestCase
         $this->client->request('GET', '/2021/04/15/this-page-is-private');
 
         self::assertResponseStatusCodeSame(Response::HTTP_OK);
-        self::assertSelectorTextSame('h1', 'This page is private');
+        self::assertSelectorTextSame('h1', 'Private: This page is private');
     }
 }

--- a/tests/Functional/Model/Menu/Builder/UserAwareMenuBuilderTest.php
+++ b/tests/Functional/Model/Menu/Builder/UserAwareMenuBuilderTest.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace NumberNine\Tests\Functional\Model\Menu\Builder;
 
 use NumberNine\Security\Capabilities;
-use NumberNine\Tests\Functional\AdminTestCase;
+use NumberNine\Tests\Functional\UserAwareTestCase;
 
-final class AdminMenuBuilderTest extends AdminTestCase
+final class UserAwareMenuBuilderTest extends UserAwareTestCase
 {
     public function setUp(): void
     {

--- a/tests/Functional/UserAwareTestCase.php
+++ b/tests/Functional/UserAwareTestCase.php
@@ -13,6 +13,7 @@ namespace NumberNine\Tests\Functional;
 
 use Doctrine\ORM\EntityManagerInterface;
 use NumberNine\Admin\AdminMenuBuilderStore;
+use NumberNine\Entity\User;
 use NumberNine\Entity\UserRole;
 use NumberNine\Model\Menu\Builder\AdminMenuBuilder;
 use NumberNine\Repository\UserRoleRepository;
@@ -20,7 +21,7 @@ use NumberNine\Security\UserFactory;
 use NumberNine\Tests\DotEnvAwareWebTestCase;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-abstract class AdminTestCase extends DotEnvAwareWebTestCase
+abstract class UserAwareTestCase extends DotEnvAwareWebTestCase
 {
     protected UserRoleRepository $userRoleRepository;
     protected UserFactory $userFactory;
@@ -67,7 +68,7 @@ abstract class AdminTestCase extends DotEnvAwareWebTestCase
         $this->adminMenuBuilder = $adminMenuBuilderStore->getAdminMenuBuilder();
     }
 
-    protected function loginAs(string $role): void
+    protected function loginAs(string $role): User
     {
         $user = $this->userFactory->createUser(
             'test',
@@ -77,5 +78,7 @@ abstract class AdminTestCase extends DotEnvAwareWebTestCase
         );
 
         $this->client->loginUser($user);
+
+        return $user;
     }
 }

--- a/tests/Unit/Content/PermalinkGeneratorTest.php
+++ b/tests/Unit/Content/PermalinkGeneratorTest.php
@@ -87,7 +87,7 @@ final class PermalinkGeneratorTest extends DotEnvAwareWebTestCase
         $this->assertEquals(sprintf('/%s/my-awesome-post', date('2016/08/07')), $permalink);
     }
 
-    public function testUnpublishedPostPermalink(): void
+    public function testUnpublishedPostAsDraftPermalink(): void
     {
         $post = (new Post())
             ->setCustomType('post')
@@ -98,7 +98,21 @@ final class PermalinkGeneratorTest extends DotEnvAwareWebTestCase
         ;
 
         $permalink = $this->permalinkGenerator->generateContentEntityPermalink($post);
-        $this->assertEquals(sprintf('/%s/my-awesome-post', date('2013/04/21')), $permalink);
+        $this->assertEquals(sprintf('/%s/my-awesome-post', date('2016/08/07')), $permalink);
+    }
+
+    public function testUnpublishedPostAsPrivatePermalink(): void
+    {
+        $post = (new Post())
+            ->setCustomType('post')
+            ->setSlug('my-awesome-post')
+            ->setStatus(PublishingStatusInterface::STATUS_PRIVATE)
+            ->setCreatedAt(new \DateTime('April 21, 2013'))
+            ->setPublishedAt(new \DateTime('August 7, 2016'))
+        ;
+
+        $permalink = $this->permalinkGenerator->generateContentEntityPermalink($post);
+        $this->assertEquals(sprintf('/%s/my-awesome-post', date('2016/08/07')), $permalink);
     }
 
     public function testPublishedPostPaginationPermalink(): void


### PR DESCRIPTION
- Throw 404 not found when accessing a private page without authorization
- Author of a private page and anyone having `read_private_posts` capability can access a private page
- Append `Private:` to private post titles
- Fix unpublished posts permalink