### PR TITLE
Customizable reset-password url prefix

### DIFF
--- a/src/Bundle/DependencyInjection/NumberNineExtension.php
+++ b/src/Bundle/DependencyInjection/NumberNineExtension.php
@@ -49,6 +49,10 @@ final class NumberNineExtension extends ConfigurableExtension implements Prepend
         ]);
 
         $container->setParameter('numbernine.config.admin_url_prefix', 'admin');
+        $container->setParameter(
+            'numbernine.config.reset_password_url_prefix',
+            '/%numbernine.config.admin_url_prefix%'
+        );
 
         $securityModified = false;
         $securityConfigs = [];

--- a/src/Bundle/Resources/config/routing.yaml
+++ b/src/Bundle/Resources/config/routing.yaml
@@ -3,9 +3,10 @@ controllers:
     type: annotation
 
 admin_controllers:
-    resource: ../../../Controller/Admin/
+    resource: '../../../Controller/Admin/**/*'
     type: annotation
     prefix: /%numbernine.config.admin_url_prefix%
+    exclude: '../../../Controller/Admin/Security/ResetPasswordController.php'
 
 admin_api_controllers:
     resource: ../../../Controller/Admin/Api

--- a/src/Bundle/Resources/views/form/tailwind_layout.html.twig
+++ b/src/Bundle/Resources/views/form/tailwind_layout.html.twig
@@ -52,7 +52,7 @@
         <div class="flex items-center justify-between">
             {%- set attr = attr|merge({class: (attr.class|default('btn btn-primary'))|trim}) -%}
             {{- parent() -}}
-            <a class="inline-block align-baseline font-bold text-sm text-blue hover:text-blue-darker" href="">
+            <a class="inline-block align-baseline font-bold text-sm text-blue hover:text-blue-darker" href="{{ path('numbernine_forgot_password_request') }}">
                 Forgot Password?
             </a>
         </div>

--- a/src/Entity/ResetPasswordRequest.php
+++ b/src/Entity/ResetPasswordRequest.php
@@ -20,8 +20,9 @@ class ResetPasswordRequest implements ResetPasswordRequestInterface
     #[ORM\JoinColumn(nullable: false)]
     private User $user;
 
-    public function __construct(DateTimeInterface $expiresAt, string $selector, string $hashedToken)
+    public function __construct(User $user, DateTimeInterface $expiresAt, string $selector, string $hashedToken)
     {
+        $this->user = $user;
         $this->initialize($expiresAt, $selector, $hashedToken);
     }
 


### PR DESCRIPTION
Example:
```yaml
parameters:
    numbernine.config.reset_password_url_prefix: /my-account
```

Defaults to `/%numbernine.config.admin_url_prefix%`